### PR TITLE
Add No index logic to meta data

### DIFF
--- a/src/Core/Core.Library.KX13/Repositories/Implementation/MetaDataRepository.cs
+++ b/src/Core/Core.Library.KX13/Repositories/Implementation/MetaDataRepository.cs
@@ -107,7 +107,7 @@ namespace Core.Repositories.Implementation
             string keywords = string.Empty;
             string description = string.Empty;
             string title = string.Empty;
-
+            Maybe<bool> noIndex = Maybe.None;
             // Try to get these values first
             /*if (node is SomePageType menuPage)
             {
@@ -156,6 +156,11 @@ namespace Core.Repositories.Implementation
                 var customDataVal = node.DocumentCustomData.GetValue("MetaData_Title");
                 title = customDataVal != null && customDataVal is string titleVal ? titleVal : node.DocumentPageTitle.AsNullOrWhitespaceMaybe().GetValueOrDefault(node.DocumentName);
             }
+            if(noIndex.HasNoValue)
+            {
+                var customDataVal = node.DocumentCustomData.GetValue("MetaData_NoIndex");
+                noIndex = customDataVal != null ? ValidationHelper.GetBoolean(customDataVal, false) : Maybe.None;
+            }
 
             PageMetaData metaData = new PageMetaData()
             {
@@ -164,6 +169,7 @@ namespace Core.Repositories.Implementation
                 Description = description.AsNullOrWhitespaceMaybe().GetValueOrDefault(string.Empty),
                 Thumbnail = thumbnail.AsNullOrWhitespaceMaybe().TryGetValue(out var thumbUrl) ? _urlResolver.GetAbsoluteUrl(thumbUrl) : string.Empty,
                 ThumbnailLarge = thumbnailLarge.AsNullOrWhitespaceMaybe().TryGetValue(out var thumbLargeUrl) ? _urlResolver.GetAbsoluteUrl(thumbLargeUrl) : string.Empty,
+                NoIndex = noIndex
             };
 
             // Handle canonical url

--- a/src/Core/Core.Library.KX13/Repositories/Implementation/MetaDataRepository.cs
+++ b/src/Core/Core.Library.KX13/Repositories/Implementation/MetaDataRepository.cs
@@ -164,11 +164,11 @@ namespace Core.Repositories.Implementation
 
             PageMetaData metaData = new PageMetaData()
             {
-                Title = title,
-                Keywords = keywords.AsNullOrWhitespaceMaybe().GetValueOrDefault(string.Empty),
-                Description = description.AsNullOrWhitespaceMaybe().GetValueOrDefault(string.Empty),
-                Thumbnail = thumbnail.AsNullOrWhitespaceMaybe().TryGetValue(out var thumbUrl) ? _urlResolver.GetAbsoluteUrl(thumbUrl) : string.Empty,
-                ThumbnailLarge = thumbnailLarge.AsNullOrWhitespaceMaybe().TryGetValue(out var thumbLargeUrl) ? _urlResolver.GetAbsoluteUrl(thumbLargeUrl) : string.Empty,
+                Title = title.AsNullOrWhitespaceMaybe(),
+                Keywords = keywords.AsNullOrWhitespaceMaybe(),
+                Description = description.AsNullOrWhitespaceMaybe(),
+                Thumbnail = thumbnail.AsNullOrWhitespaceMaybe().TryGetValue(out var thumbUrl) ? _urlResolver.GetAbsoluteUrl(thumbUrl) : Maybe.None,
+                ThumbnailLarge = thumbnailLarge.AsNullOrWhitespaceMaybe().TryGetValue(out var thumbLargeUrl) ? _urlResolver.GetAbsoluteUrl(thumbLargeUrl) : Maybe.None,
                 NoIndex = noIndex
             };
 

--- a/src/Core/Core.Models/Models/PageMetaData.cs
+++ b/src/Core/Core.Models/Models/PageMetaData.cs
@@ -8,5 +8,6 @@
         public Maybe<string> Thumbnail { get; set; }
         public Maybe<string> ThumbnailLarge { get; set; }
         public Maybe<string> CanonicalUrl { get; set; }
+        public Maybe<bool> NoIndex { get; set; }
     }
 }

--- a/src/Core/Core.RCL/Components/PageMetaData/PageMetaData.cshtml
+++ b/src/Core/Core.RCL/Components/PageMetaData/PageMetaData.cshtml
@@ -1,26 +1,31 @@
 ﻿@model Core.Components.PageMetaData.PageMetaDataViewModel
 @inject IUrlHelper UrlHelper
-@inject IUrlResolver UrlResolver 
+@inject IUrlResolver UrlResolver
 
-@if (Model.Title.TryGetValue(out var title))
+@if (Model.Title.TryGetValue(out var title) && !string.IsNullOrWhiteSpace(title))
 {
     ViewBag.Title = title;
     <title>@title</title>
     <meta property="og:title" content="@title" />
 }
-@if (Model.Description.TryGetValue(out var description))
+@if (Model.Description.TryGetValue(out var description) && !string.IsNullOrWhiteSpace(description))
 {
     <meta name="description" content="@description">
     <meta property="og:description" content="@description" />
 }
-@if (Model.Keywords.TryGetValue(out var keywords))
+@if (Model.Keywords.TryGetValue(out var keywords) && !string.IsNullOrWhiteSpace(keywords))
 {
     <meta name="keywords" content="@keywords">
 }
-@if (Model.Thumbnail.TryGetValue(out var thumbnail))
+@if (Model.Thumbnail.TryGetValue(out var thumbnail) && !string.IsNullOrWhiteSpace(thumbnail))
 {
     <meta property="og:image" content="@UrlResolver.GetAbsoluteUrl(thumbnail)" />
 }
-@if(Model.CanonicalUrl.TryGetValue(out var canonicalUrl)) {
+@if (Model.CanonicalUrl.TryGetValue(out var canonicalUrl) && !string.IsNullOrWhiteSpace(canonicalUrl))
+{
     <link rel="canonical" href="@UrlResolver.GetAbsoluteUrl(canonicalUrl)" />
+}
+@if (Model.NoIndex.TryGetValue(out var noIndex) && noIndex)
+{
+    <meta name="robots" content="noindex">
 }

--- a/src/Core/Core.RCL/Components/PageMetaData/PageMetaData.cshtml
+++ b/src/Core/Core.RCL/Components/PageMetaData/PageMetaData.cshtml
@@ -2,26 +2,26 @@
 @inject IUrlHelper UrlHelper
 @inject IUrlResolver UrlResolver
 
-@if (Model.Title.TryGetValue(out var title) && !string.IsNullOrWhiteSpace(title))
+@if (Model.Title.TryGetValue(out var title))
 {
     ViewBag.Title = title;
     <title>@title</title>
     <meta property="og:title" content="@title" />
 }
-@if (Model.Description.TryGetValue(out var description) && !string.IsNullOrWhiteSpace(description))
+@if (Model.Description.TryGetValue(out var description))
 {
     <meta name="description" content="@description">
     <meta property="og:description" content="@description" />
 }
-@if (Model.Keywords.TryGetValue(out var keywords) && !string.IsNullOrWhiteSpace(keywords))
+@if (Model.Keywords.TryGetValue(out var keywords))
 {
     <meta name="keywords" content="@keywords">
 }
-@if (Model.Thumbnail.TryGetValue(out var thumbnail) && !string.IsNullOrWhiteSpace(thumbnail))
+@if (Model.Thumbnail.TryGetValue(out var thumbnail))
 {
     <meta property="og:image" content="@UrlResolver.GetAbsoluteUrl(thumbnail)" />
 }
-@if (Model.CanonicalUrl.TryGetValue(out var canonicalUrl) && !string.IsNullOrWhiteSpace(canonicalUrl))
+@if (Model.CanonicalUrl.TryGetValue(out var canonicalUrl))
 {
     <link rel="canonical" href="@UrlResolver.GetAbsoluteUrl(canonicalUrl)" />
 }


### PR DESCRIPTION
Added NoIndex property to PageMetaData, and added rendering

Also fixed default MetaDataRepository to not return empty strings but Maybe.None.