### PR TITLE
Typed Page Identity Context Linked Item Depth Control and Extension Methods

### DIFF
--- a/documentation/core/core-page-identity.md
+++ b/documentation/core/core-page-identity.md
@@ -18,7 +18,7 @@ The PageIdentity also has a Generic typed version, which revelas a Data property
 
 You can leverage this to include additional data with your PageIdentity (such as your actual Content Type model, Reusable Schema data, or a DTO of it).
 
-If you retrieve a PageIdentity of one type, and wish to convert it to a PageIdentity of a different type, there is the [IPageIdentityFactory.Convert](../../src/Core/Core.Models/Services/IPageIdentityFactory.cs) which allows you to convert the Data from one type to another easily.
+If you retrieve a PageIdentity of one type, and wish to convert it to a PageIdentity of a different type, there is the [IPageIdentityFactory.Convert](../../src/Core/Core.Models/Services/IPageIdentityFactory.cs) which allows you to convert the Data from one type to another easily, or even easier, the `PageIdentity.ToTypedPageIdentity` methods which do the same thing.
 
 
 ## IPageContextRepository
@@ -33,7 +33,7 @@ Here's a breakdown of the methods and their uses.
 
 **GetCurrentPageAsync T** / **GetPageAsync T**: Typed version of GetCurrentPageAsync() and GetPageAsync, can pass your Content Type or Reusable Schema type as the parameter, and if the current page is that type (or inherits from that reusable schema), it will return the PageIdentity WITH the T Data property of the type you requested (Result.Failure if couldn't find or parse);
 
-This uses the `IMappedContentItemRepository`
+This uses the `IMappedContentItemRepository`.  Since the depth of the Linked Items may need to be controlled, there is also an `IMappedContentItemLinkedItemDepthRetriever` that you can implement adjust the Linked Items given the Class Name (Default 100).
 
 ### Leveraging the Typed GetPageAsync/GetCurrentPageAsync
 The IPageContextRepository.GetCurrentPageAsync<T> or GetPageAsync<T> are very useful both for your initial Page Templates (to get the model without needing additional parsing each time), but also for "Current Page" related View Components.  For example, if you have an `IBanners` Reusable Schema that links to `Banner` Content Types.  Some pages have banners, some do not.

--- a/src/Core/Core.Library.KX13/Extensions/PageIdentityExtensions.cs
+++ b/src/Core/Core.Library.KX13/Extensions/PageIdentityExtensions.cs
@@ -1,0 +1,11 @@
+﻿namespace Core.Models
+{
+    public static class PageIdentityExtensions
+    {
+        public static PageIdentity<T> ToTypedPageIdentity<T>(this PageIdentity pageIdentity, T model) => new(model, pageIdentity);
+
+        public static PageIdentity<T> ToTypedPageIdentity<T, TOriginalType>(this PageIdentity<TOriginalType> pageIdentity, T model) => new(model, pageIdentity);
+
+        public static PageIdentity<T> ToTypedPageIdentity<T, TOriginalType>(this PageIdentity<TOriginalType> pageIdentity, Func<TOriginalType, T> converter) => new(converter.Invoke(pageIdentity.Data), pageIdentity);
+    }
+}

--- a/src/Core/Core.Library.Xperience/Extensions/BaselineCoreFieldsSourceExtensions.cs
+++ b/src/Core/Core.Library.Xperience/Extensions/BaselineCoreFieldsSourceExtensions.cs
@@ -1,0 +1,35 @@
+﻿namespace CMS.Websites
+{
+    public static class BaselineCoreFieldsSourceExtensions
+    {
+        public static TreeIdentity ToTreeIdentity(this IWebPageFieldsSource webpageData) => new() {
+            PageID = webpageData.SystemFields.WebPageItemID,
+            PageGuid = webpageData.SystemFields.WebPageItemGUID,
+            PageName = webpageData.SystemFields.WebPageItemName,
+            PathChannelLookup = new PathChannel(webpageData.SystemFields.WebPageItemTreePath, webpageData.SystemFields.WebPageItemWebsiteChannelId)
+        };
+
+        public static TreeCultureIdentity ToTreeCultureIdentity(this IWebPageFieldsSource webpageData, ILanguageIdentifierRepository languageIdentifierRepository) => new(languageIdentifierRepository.LanguageIdToName(webpageData.SystemFields.ContentItemCommonDataContentLanguageID)) {
+            PageID = webpageData.SystemFields.WebPageItemID,
+            PageGuid = webpageData.SystemFields.WebPageItemGUID,
+            PageName = webpageData.SystemFields.WebPageItemName,
+            PathChannelLookup = new PathChannel(webpageData.SystemFields.WebPageItemTreePath, webpageData.SystemFields.WebPageItemWebsiteChannelId)
+        };
+
+        public static ContentIdentity ToContentIdentity(this IContentItemFieldsSource contentData) => new() {
+            ContentID = contentData.SystemFields.ContentItemID,
+            ContentGuid = contentData.SystemFields.ContentItemGUID,
+            ContentName = contentData.SystemFields.ContentItemName
+        };
+
+        /// <summary>
+        /// This will only fill the ContentCultureLookup, as the other fields are unavailable.
+        /// </summary>
+        /// <param name="contentData"></param>
+        /// <param name="languageIdentifierRepository"></param>
+        /// <returns></returns>
+        public static ContentCultureIdentity ToContentIdentity(this IContentItemFieldsSource contentData, ILanguageIdentifierRepository languageIdentifierRepository) => new() {
+            ContentCultureLookup = new ContentCulture(contentData.SystemFields.ContentItemID, languageIdentifierRepository.LanguageIdToName(contentData.SystemFields.ContentItemCommonDataContentLanguageID))
+        };
+    }
+}

--- a/src/Core/Core.Library.Xperience/Extensions/BaselineCoreIWebPageContentQueryDataContainerExtensions.cs
+++ b/src/Core/Core.Library.Xperience/Extensions/BaselineCoreIWebPageContentQueryDataContainerExtensions.cs
@@ -21,5 +21,6 @@
             ContentGuid = webpageData.ContentItemGUID,
             ContentName = webpageData.ContentItemName
         };
+
     }
 }

--- a/src/Core/Core.Library.Xperience/Extensions/PageIdentityExtensions.cs
+++ b/src/Core/Core.Library.Xperience/Extensions/PageIdentityExtensions.cs
@@ -1,0 +1,11 @@
+﻿namespace Core.Models
+{
+    public static class PageIdentityExtensions
+    {
+        public static PageIdentity<T> ToTypedPageIdentity<T>(this PageIdentity pageIdentity, T model) => new(model, pageIdentity);
+
+        public static PageIdentity<T> ToTypedPageIdentity<T, TOriginalType>(this PageIdentity<TOriginalType> pageIdentity, T model) => new(model, pageIdentity);
+
+        public static PageIdentity<T> ToTypedPageIdentity<T, TOriginalType>(this PageIdentity<TOriginalType> pageIdentity, Func<TOriginalType, T> converter) => new(converter.Invoke(pageIdentity.Data), pageIdentity);
+    }
+}

--- a/src/Core/Core.Library.Xperience/Repositories/IMappedContentItemLinkedItemDepthRetriever.cs
+++ b/src/Core/Core.Library.Xperience/Repositories/IMappedContentItemLinkedItemDepthRetriever.cs
@@ -1,0 +1,10 @@
+﻿namespace Core.Repositories
+{
+    /// <summary>
+    /// Customizable to control the Linked Item depth when the IMappedContentRepository retrieves data (used in the IPageContextRepository retrieval logic)
+    /// </summary>
+    public interface IMappedContentItemLinkedItemDepthRetriever
+    {
+        public int GetLinkedItemDepth(string className);
+    }
+}

--- a/src/Core/Core.Library.Xperience/Repositories/Implementation/MappedContentItemLinkedItemDepthRetriever.cs
+++ b/src/Core/Core.Library.Xperience/Repositories/Implementation/MappedContentItemLinkedItemDepthRetriever.cs
@@ -1,0 +1,11 @@
+﻿namespace Core.Repositories.Implementation
+{
+    public class MappedContentItemLinkedItemDepthRetriever : IMappedContentItemLinkedItemDepthRetriever
+    {
+        public int GetLinkedItemDepth(string className)
+        {
+            // Default, override in your own custom implementation
+            return 100;
+        }
+    }
+}

--- a/src/Core/Core.RCL.Xperience/Middleware/CoreMiddleware.cs
+++ b/src/Core/Core.RCL.Xperience/Middleware/CoreMiddleware.cs
@@ -119,6 +119,7 @@ namespace Core
                 .AddTransient<IMetaDataWebPageDataContainerConverter, MetaDataWebPageDataContainerConverter>()
                 .AddScoped<IPageContextRepository, PageContextRepository>()
                 .AddScoped<IMappedContentItemRepository, MappedContentItemRepository>()
+                .AddScoped<IMappedContentItemLinkedItemDepthRetriever, MappedContentItemLinkedItemDepthRetriever>()
                 .AddScoped<IMetaDataRepository, MetaDataRepository>();
 
             // User Customization Points, register your own versions afterwards if you wish
@@ -132,6 +133,7 @@ namespace Core
 #pragma warning disable CS0618 // Type or member is obsolete - keeping for fallback purposes
                 .AddScoped<IWebPageToPageMetadataConverter, DefaultContentItemToPageMetadataConverter>()
 #pragma warning restore CS0618 // Type or member is obsolete
+                
 
                 // Main item retrieval that depends on baseline apis and user customizations
                 .AddScoped<IUserRepository, UserRepository<TUser>>()


### PR DESCRIPTION
Added a MappedContentItemLinkedItemDepthRetriever so can customize link depth for PageContextRetriever, as well as some extension methods to make certain operations easier.