### PR TITLE
#26 - Metadata issue and upgrade to latest hotfix

### DIFF
--- a/src/Account/Account.Library.Xperience/Account.Library.Xperience.csproj
+++ b/src/Account/Account.Library.Xperience/Account.Library.Xperience.csproj
@@ -19,7 +19,7 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="Kentico.Xperience.WebApp" Version="30.3.0" />
+    <PackageReference Include="Kentico.Xperience.WebApp" Version="30.4.0" />
     <PackageReference Include="XperienceCommunity.ChannelSettings" Version="1.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.Facebook" Version="8.0.10" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.Google" Version="8.0.10" />

--- a/src/Account/Account.RCL.Xperience/Account.RCL.Xperience.csproj
+++ b/src/Account/Account.RCL.Xperience/Account.RCL.Xperience.csproj
@@ -24,7 +24,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Kentico.Xperience.WebApp" Version="30.3.0" />
+    <PackageReference Include="Kentico.Xperience.WebApp" Version="30.4.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Core/Core.Admin.Xperience/Core.Admin.Xperience.csproj
+++ b/src/Core/Core.Admin.Xperience/Core.Admin.Xperience.csproj
@@ -19,7 +19,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Kentico.Xperience.Admin" Version="30.3.0" />
+    <PackageReference Include="Kentico.Xperience.Admin" Version="30.4.0" />
     <PackageReference Include="XperienceCommunity.ChannelSettings.Admin" Version="1.2.0" />
     <PackageReference Include="XperienceCommunity.MemberRoles.Admin" Version="2.3.2" />
     <PackageReference Include="XperienceCommunity.RelationshipsExtended.Admin" Version="1.0.1" />

--- a/src/Core/Core.Library.Xperience/Core.Library.Xperience.csproj
+++ b/src/Core/Core.Library.Xperience/Core.Library.Xperience.csproj
@@ -24,7 +24,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Kentico.Xperience.WebApp" Version="30.3.0" />
+    <PackageReference Include="Kentico.Xperience.WebApp" Version="30.4.0" />
     <PackageReference Include="XperienceCommunity.ChannelSettings" Version="1.2.0" />
     <PackageReference Include="XperienceCommunity.DevTools.MVCCaching" Version="2.0.1" />
     <PackageReference Include="XperienceCommunity.DevTools.QueryExtensions" Version="3.0.0" />

--- a/src/Core/Core.Library.Xperience/Repositories/IContentItemToPageMetadataConverter.cs
+++ b/src/Core/Core.Library.Xperience/Repositories/IContentItemToPageMetadataConverter.cs
@@ -4,21 +4,39 @@ namespace Core.Repositories
 {
     public interface IContentItemToPageMetadataConverter
     {
-            /// <summary>
-            /// This allows you to do custom mapping and adjustments from the base metadata.  This is useful if you want to add custom URL routing, titles, thumbnails, etc based on the type.
-            /// </summary>
-            /// <param name="webPageContentQueryDataContainer">The raw item</param>
-            /// <param name="baseMetaData">This is the base metadata (what will be used if you do not modify and return a result). Leverages fields from the IBaseMetaData if available.</param>
-            /// <returns></returns>
-            Task<Result<PageMetaData>> MapAndGetPageMetadata(IWebPageContentQueryDataContainer webPageContentQueryDataContainer, PageMetaData baseMetaData);
+        /// <summary>
+        /// This allows you to do custom mapping and adjustments from the base metadata.  This is useful if you want to add custom URL routing, titles, thumbnails, etc based on the type.
+        /// </summary>
+        /// <param name="webPageContentQueryDataContainer">The raw item</param>
+        /// <param name="baseMetaData">This is the base metadata (what will be used if you do not modify and return a result). Leverages fields from the IBaseMetaData if available.</param>
+        /// <returns></returns>
+        Task<Result<PageMetaData>> MapAndGetPageMetadata(IWebPageContentQueryDataContainer webPageContentQueryDataContainer, PageMetaData baseMetaData);
 
-            /// <summary>
-            /// This allows you to do custom mapping and adjustments from the base metadata for non-webpage items.  This is useful if you want to add custom URL routing, titles, thumbnails, etc based on the type.
-            /// </summary>
-            /// <param name="contentQueryDataContainer">The raw item</param>
-            /// <param name="baseMetaData">This is the base metadata (what will be used if you do not modify and return a result). Leverages fields from the IBaseMetaData if available.</param>
-            /// <param name="canonicalUrl">The Canonical Url that was passed to generate the original PageMetaData.</param>
-            /// <returns></returns>
-            Task<Result<PageMetaData>> MapAndGetPageMetadataReusableContent(IContentQueryDataContainer contentQueryDataContainer, PageMetaData baseMetaData, string? canonicalUrl);
+        /// <summary>
+        /// This allows you to do custom mapping and adjustments from the base metadata.  This is useful if you want to add custom URL routing, titles, thumbnails, etc based on the type.
+        /// </summary>
+        /// <param name="webPageFieldSource">The converted web page (it is a class so can check for type casting)</param>
+        /// <param name="baseMetaData">This is the base metadata (what will be used if you do not modify and return a result). Leverages fields from the IBaseMetaData if available.</param>
+        /// <returns></returns>
+        Task<Result<PageMetaData>> MapAndGetPageMetadata(IWebPageFieldsSource webPageFieldSource, PageMetaData baseMetaData);
+
+
+        /// <summary>
+        /// This allows you to do custom mapping and adjustments from the base metadata for non-webpage items.  This is useful if you want to add custom URL routing, titles, thumbnails, etc based on the type.
+        /// </summary>
+        /// <param name="contentQueryDataContainer">The raw item</param>
+        /// <param name="baseMetaData">This is the base metadata (what will be used if you do not modify and return a result). Leverages fields from the IBaseMetaData if available.</param>
+        /// <param name="canonicalUrl">The Canonical Url that was passed to generate the original PageMetaData.</param>
+        /// <returns></returns>
+        Task<Result<PageMetaData>> MapAndGetPageMetadataReusableContent(IContentQueryDataContainer contentQueryDataContainer, PageMetaData baseMetaData, string? canonicalUrl);
+
+        /// <summary>
+        /// This allows you to do custom mapping and adjustments from the base metadata for non-webpage items.  This is useful if you want to add custom URL routing, titles, thumbnails, etc based on the type.
+        /// </summary>
+        /// <param name="contentItemFieldSource">The converted content item (it is a class so can check for type casting)</param>
+        /// <param name="baseMetaData">This is the base metadata (what will be used if you do not modify and return a result). Leverages fields from the IBaseMetaData if available.</param>
+        /// <param name="canonicalUrl">The Canonical Url that was passed to generate the original PageMetaData.</param>
+        /// <returns></returns>
+        Task<Result<PageMetaData>> MapAndGetPageMetadataReusableContent(IContentItemFieldsSource contentItemFieldSource, PageMetaData baseMetaData, string? canonicalUrl);
     }
 }

--- a/src/Core/Core.Library.Xperience/Repositories/Implementation/DefaultContentItemToPageMetadataConverter.cs
+++ b/src/Core/Core.Library.Xperience/Repositories/Implementation/DefaultContentItemToPageMetadataConverter.cs
@@ -12,7 +12,17 @@ namespace Core.Repositories.Implementation
             return Task.FromResult(Result.Failure<PageMetaData>("If you want to customize, must implement and inject your own. Use IContentQueryResultMapper.Map to cast the contentQueryDataContainer to your type"));
         }
 
+        public Task<Result<PageMetaData>> MapAndGetPageMetadata(IWebPageFieldsSource webPageFieldSource, PageMetaData baseMetaData)
+        {
+            return Task.FromResult(Result.Failure<PageMetaData>("If you want to customize, must implement and inject your own. Use IContentQueryResultMapper.Map to cast the contentQueryDataContainer to your type"));
+        }
+
         public Task<Result<PageMetaData>> MapAndGetPageMetadataReusableContent(IContentQueryDataContainer contentQueryDataContainer, PageMetaData baseMetaData, string? canonicalUrl)
+        {
+            return Task.FromResult(Result.Failure<PageMetaData>("If you want to customize, must implement and inject your own. Use IContentQueryResultMapper.Map to cast the contentQueryDataContainer to your type"));
+        }
+
+        public Task<Result<PageMetaData>> MapAndGetPageMetadataReusableContent(IContentItemFieldsSource contentItemFieldSource, PageMetaData baseMetaData, string? canonicalUrl)
         {
             return Task.FromResult(Result.Failure<PageMetaData>("If you want to customize, must implement and inject your own. Use IContentQueryResultMapper.Map to cast the contentQueryDataContainer to your type"));
         }

--- a/src/Core/Core.Library.Xperience/Services/IMetaDataWebPageDataContainerConverter.cs
+++ b/src/Core/Core.Library.Xperience/Services/IMetaDataWebPageDataContainerConverter.cs
@@ -12,5 +12,7 @@ namespace Core.Services
         /// <param name="canonicalUrl"></param>
         /// <returns></returns>
         Task<Result<PageMetaData>> GetDefaultMetadataLogic(IContentQueryDataContainer nonWebpageContentQueryDataContainer, string? canonicalUrl);
+        Task<Result<PageMetaData>> GetDefaultMetadataLogic(IWebPageFieldsSource webPageFieldSource);
+        Task<Result<PageMetaData>> GetDefaultMetadataLogic(IContentItemFieldsSource nonWebpageContentItemFieldSource, string? canonicalUrl);
     }
 }

--- a/src/Core/Core.Models/Models/ContentIdentity.cs
+++ b/src/Core/Core.Models/Models/ContentIdentity.cs
@@ -200,5 +200,6 @@
             }
             return (await identityService.HydrateContentCultureIdentity(identity)).TryGetValue(out var hydrated, out var error) && hydrated.ContentCultureLookup.TryGetValue(out var hydratedValue) ? hydratedValue : Result.Failure<ContentCulture>(error);
         }
+
     }
 }

--- a/src/Core/Core.RCL.Xperience/Core.RCL.Xperience.csproj
+++ b/src/Core/Core.RCL.Xperience/Core.RCL.Xperience.csproj
@@ -20,7 +20,7 @@
   </ItemGroup>
 
 	<ItemGroup>
-	  <PackageReference Include="Kentico.Xperience.WebApp" Version="30.3.0" />
+	  <PackageReference Include="Kentico.Xperience.WebApp" Version="30.4.0" />
 	  <PackageReference Include="XperienceCommunity.ImageProcessing" Version="1.1.1" />
 	  <PackageReference Include="XperienceCommunity.PartialWidgetPage" Version="30.0.3" />
 	</ItemGroup>

--- a/src/Core/Core.XperienceModels.Xperience/Core.XperienceModels.Xperience.csproj
+++ b/src/Core/Core.XperienceModels.Xperience/Core.XperienceModels.Xperience.csproj
@@ -19,7 +19,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Kentico.Xperience.WebApp" Version="30.3.0" />
+    <PackageReference Include="Kentico.Xperience.WebApp" Version="30.4.0" />
     <PackageReference Include="XperienceCommunity.MemberRoles" Version="2.3.2" />
   </ItemGroup>
 

--- a/src/Localization/Localization.RCL.Xperience/Localization.RCL.Xperience.csproj
+++ b/src/Localization/Localization.RCL.Xperience/Localization.RCL.Xperience.csproj
@@ -24,7 +24,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Kentico.Xperience.WebApp" Version="30.3.0" />
+    <PackageReference Include="Kentico.Xperience.WebApp" Version="30.4.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Navigation/Navigation.Library.Xperience/Navigation.Library.Xperience.csproj
+++ b/src/Navigation/Navigation.Library.Xperience/Navigation.Library.Xperience.csproj
@@ -19,7 +19,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Kentico.Xperience.WebApp" Version="30.3.0" />
+    <PackageReference Include="Kentico.Xperience.WebApp" Version="30.4.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Revamp of Metadata was non fully completed, I needed to cast the objects into their native Content Item classes before doing type checking, I was passing the raw Data.  Updated classes and added appropriate new interface methods to handle things better.

Also updated packages to 30.4