### PR TITLE
Update PageContextRepository.cs

### DIFF
--- a/src/Core/Core.Library.Xperience/Repositories/Implementation/PageContextRepository.cs
+++ b/src/Core/Core.Library.Xperience/Repositories/Implementation/PageContextRepository.cs
@@ -113,10 +113,12 @@ namespace Core.Repositories.Implementation
                 return (await XperienceCommunityConnectionHelper.ExecuteQueryAsync(query, [], QueryTypeEnum.SQLQuery)).Tables[0].Rows.Cast<DataRow>()
                 .GroupBy(x => (int)x["WebPageItemID"])
                 .ToDictionary(key => key.Key, value =>
-                    value.ToDictionary(key => ((string)key["ContentLanguageName"]).ToLowerInvariant(),
-                        value => DataRowToPageIdentity(value)
-                        )
-                    );
+                    value
+                        .GroupBy(x => ((string)x["ContentLanguageName"]).ToLowerInvariant())
+                        .ToDictionary(
+                            g => g.Key,
+                            g => DataRowToPageIdentity(g.First())
+                        );
             }, new CacheSettings(CacheMinuteTypes.VeryLong.ToDouble(), "GetPageIdentityByWebpageIdAndLanguage"));
         }
         private readonly string _baseQuery = @"


### PR DESCRIPTION
Fix for Vanity URLs issue - when creating multiple page Vanity URLs you get this error message on all the site pages: "An item with the same key has already been added. Key: en ..." - Baseline was likely written before Xperience's current Vanity URL implementation or assumes that CMS_WebPageUrlPath contains only one "latest" URL per page/language. With Xperience 31.5.3 that assumption appears invalid.